### PR TITLE
Add flag for HTTP Basic authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ docker run -p 9142:9142 expressenab/bigip_exporter -bigip.host <bigip-host> -big
 ### Flags
 Flag | Description | Default
 -----|-------------|---------
+-bigip.basic_auth | Use HTTP Basic instead of Token for authentication | localhost
 -bigip.host | BIG-IP host | localhost
 -bigip.port | BIG-IP port | 443
 -bigip.username | BIG-IP username | user

--- a/bigip_exporter.go
+++ b/bigip_exporter.go
@@ -12,6 +12,7 @@ import (
 )
 
 var (
+	bigip_basic_auth      = flag.Bool("bigip.basic_auth",false, "Use HTTP Basic authentication")
 	bigip_host            = flag.String("bigip.host", "localhost", "The host on which f5 resides")
 	bigip_port            = flag.Int("bigip.port", 443, "The port which f5 listens to")
 	bigip_username        = flag.String("bigip.username", "user", "Username")
@@ -46,7 +47,11 @@ func main() {
 	} else {
 		exporter_partitions_list = nil
 	}
-	bigip := f5.New(bigip_endpoint, *bigip_username, *bigip_password, f5.TOKEN)
+	auth_method:=f5.TOKEN
+	if *bigip_basic_auth {
+	  auth_method=f5.BASIC_AUTH
+	}
+	bigip := f5.New(bigip_endpoint, *bigip_username, *bigip_password, auth_method)
 
 	_, bigipCollector := collector.NewBigIpCollector(bigip, exporter_namespace, exporter_partitions_list)
 


### PR DESCRIPTION
Tested 11.5.4 with Token-based authentication but it does not work. This commit allows the use of HTTP Basic Auth instead, successfully tested. User must be a local administrator, remote groups doesn't work with HTTP Basic.
